### PR TITLE
improve hexedits

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ IndentWidth:                    4
 InsertBraces:                   true
 SortIncludes:                   CaseInsensitive
 IncludeCategories:
-  - Regex:                      '"pch.h"'
+  - Regex:                      '"unrealsdk/pch\.h"'
     Priority:                   -1
     CaseSensitive:              true
 ---

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,16 +37,14 @@ CheckOptions:
     cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: true
     misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: true
 
-    readability-identifier-naming.ConstantCase:         UPPER_CASE
+    readability-identifier-naming.GlobalConstantCase:   UPPER_CASE
     readability-identifier-naming.MacroDefinitionCase:  UPPER_CASE
 
     readability-identifier-naming.ClassCase:            CamelCase
     readability-identifier-naming.EnumCase:             CamelCase
     readability-identifier-naming.StructCase:           CamelCase
 
-    readability-identifier-naming.ConstantMemberCase:   lower_case
     readability-identifier-naming.FunctionCase:         lower_case
-    readability-identifier-naming.LocalConstantCase:    lower_case
     readability-identifier-naming.MemberCase:           lower_case
     readability-identifier-naming.NamespaceCase:        lower_case
     readability-identifier-naming.ParameterCase:        lower_case

--- a/src/unrealsdk/game/tps/hexedits.cpp
+++ b/src/unrealsdk/game/tps/hexedits.cpp
@@ -11,21 +11,23 @@ namespace unrealsdk::game {
 
 namespace {
 
-const Pattern ARRAY_LIMIT_MESSAGE{"\x7C\x7B\x8B\x8D\x94\xEE\xFF\xFF",
-                                  "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"};
+// This is actually the exact same sig as BL2 when we trim the leading any bytes, but the jump is
+// encoded differently
+const Pattern ARRAY_LIMIT_MESSAGE{"\x00\x00\x8B\x8D\x00\x00\x00\x00\x83\xC0\x9D",
+                                  "\x00\x00\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF"};
 
-}
+}  // namespace
 
 void TPSHook::hexedit_array_limit_message(void) const {
     auto array_limit_msg = sigscan<uint8_t*>(ARRAY_LIMIT_MESSAGE);
     if (array_limit_msg == nullptr) {
-        LOG(MISC, "Couldn't find array limit message signature, assuming already hex edited");
+        LOG(ERROR, "Couldn't find array limit message signature");
     } else {
         LOG(MISC, "Array Limit Message: {:p}", reinterpret_cast<void*>(array_limit_msg));
 
         // NOLINTBEGIN(readability-magic-numbers)
         unlock_range(array_limit_msg, 1);
-        array_limit_msg[0] = 0x75;
+        array_limit_msg[0] = 0xEB;
         // NOLINTEND(readability-magic-numbers)
     }
 }

--- a/src/unrealsdk/memory.h
+++ b/src/unrealsdk/memory.h
@@ -1,7 +1,6 @@
 #ifndef UNREALSDK_SIGSCAN_H
 #define UNREALSDK_SIGSCAN_H
 
-#include <vadefs.h>
 #include "unrealsdk/pch.h"
 
 namespace unrealsdk::memory {
@@ -11,10 +10,14 @@ namespace unrealsdk::memory {
  */
 struct Pattern {
    public:
-    const uint8_t* bytes;
-    const uint8_t* mask;
-    const size_t offset;
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+
+    const uint8_t* const bytes;
+    const uint8_t* const mask;
+    const ptrdiff_t offset;
     const size_t size;
+
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
     /**
      * @brief Construct a pattern from strings.
@@ -26,7 +29,7 @@ struct Pattern {
      * @return A sigscan pattern.
      */
     template <size_t n>
-    Pattern(const char (&bytes)[n], const char (&mask)[n], size_t offset = 0)
+    Pattern(const char (&bytes)[n], const char (&mask)[n], ptrdiff_t offset = 0)
         : bytes(reinterpret_cast<const uint8_t*>(bytes)),
           mask(reinterpret_cast<const uint8_t*>(mask)),
           offset(offset),


### PR DESCRIPTION
instruction align patterns
make patterns agnostic to if they've already been applied
replace the stupid old "replace the condition" edits with just making the jump unconditional/noping them