### PR TITLE
migrate to string views where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ sdk can work with multiple (somewhat similar) UE versions from a single binary, 
 it how exactly to hook everything. The easiest way is to let it autodetect.
 
 ```cpp
-unrealsdk::init(unrealsdk::game::select_based_on_executable());
+unrealsdk::init(unrealsdk::game::select_based_on_executable);
 ```
 If this doesn't work correctly, you can always implement your own version (and then merge it back
 into this project).

--- a/src/shared/dllmain.cpp
+++ b/src/shared/dllmain.cpp
@@ -15,7 +15,7 @@ HMODULE this_module;
  */
 DWORD WINAPI startup_thread(LPVOID /*unused*/) {
     try {
-        unrealsdk::init(unrealsdk::game::select_based_on_executable());
+        unrealsdk::init(unrealsdk::game::select_based_on_executable);
     } catch (std::exception& ex) {
         LOG(ERROR, "Exception occurred while initializing the sdk: {}", ex.what());
     }

--- a/src/unrealsdk/commands.h
+++ b/src/unrealsdk/commands.h
@@ -44,7 +44,7 @@ using Callback = DLLSafeCallback::InnerFunc;
  * @param callback The callback for when the command is run.
  * @return True if successfully added, false if an identical command already exists.
  */
-bool add_command(const std::wstring& cmd, const Callback& callback);
+bool add_command(std::wstring_view cmd, const Callback& callback);
 
 /**
  * @brief Check if a custom console command is registered.
@@ -52,7 +52,7 @@ bool add_command(const std::wstring& cmd, const Callback& callback);
  * @param cmd The command to match.
  * @return True if the command is registered.
  */
-bool has_command(const std::wstring& cmd);
+bool has_command(std::wstring_view cmd);
 
 /**
  * @brief Removes a custom console command.
@@ -60,7 +60,7 @@ bool has_command(const std::wstring& cmd);
  * @param cmd The command to remove.
  * @return True if successfully removed, false if no such command exists.
  */
-bool remove_command(const std::wstring& cmd);
+bool remove_command(std::wstring_view cmd);
 
 namespace impl {  // These functions are only relevant when implementing a game hook
 
@@ -73,7 +73,7 @@ namespace impl {  // These functions are only relevant when implementing a game 
  * @return A pair of the callback to run and the offset to pass to it, or of nullptr and 0 if there
  *         was no match.
  */
-std::pair<DLLSafeCallback*, size_t> find_matching_command(const std::wstring& line);
+std::pair<DLLSafeCallback*, size_t> find_matching_command(std::wstring_view line);
 
 #endif
 }  // namespace impl

--- a/src/unrealsdk/env.cpp
+++ b/src/unrealsdk/env.cpp
@@ -8,7 +8,7 @@ namespace unrealsdk::env {
 #ifndef UNREALSDK_IMPORTING
 
 void load_file(void) {
-    std::ifstream stream{utils::get_this_dll_dir() / get(ENV_FILE, defaults::ENV_FILE)};
+    std::ifstream stream{utils::get_this_dll().parent_path() / get(ENV_FILE, defaults::ENV_FILE)};
 
     std::string line;
     while (std::getline(stream, line)) {

--- a/src/unrealsdk/env.cpp
+++ b/src/unrealsdk/env.cpp
@@ -33,28 +33,17 @@ bool defined(env_var_key env_var) {
     return GetEnvironmentVariableA(env_var, nullptr, 0) != 0;
 }
 
-std::string get(env_var_key env_var, const std::string& default_value) {
-    auto size = GetEnvironmentVariableA(env_var, nullptr, 0);
-    if (size == 0) {
-        return default_value;
+std::string get(env_var_key env_var, std::string_view default_value) {
+    auto num_chars = GetEnvironmentVariableA(env_var, nullptr, 0);
+    if (num_chars == 0) {
+        return std::string{default_value};
     }
 
-    // NOLINTBEGIN(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory)
-    auto buf = reinterpret_cast<char*>(malloc(size * sizeof(char)));
-    if (buf == nullptr) {
-        return default_value;
+    // The returned size on failure includes a null terminator, but on success does not.
+    std::string ret(num_chars - 1, '\0');
+    if (GetEnvironmentVariableA(env_var, ret.data(), num_chars) != (num_chars - 1)) {
+        return std::string{default_value};
     }
-
-    if (GetEnvironmentVariableA(env_var, buf, size) == 0) {
-        free(buf);
-        return default_value;
-    }
-
-    // Size includes the null terminator
-    std::string ret{buf, size - 1};
-
-    free(buf);
-    // NOLINTEND(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory)
 
     return ret;
 }

--- a/src/unrealsdk/env.h
+++ b/src/unrealsdk/env.h
@@ -1,6 +1,8 @@
 #ifndef UNREALSDK_ENV_H
 #define UNREALSDK_ENV_H
 
+#include "unrealsdk/pch.h"
+
 namespace unrealsdk::env {
 using env_var_key = const char*;
 
@@ -67,7 +69,7 @@ bool defined(env_var_key env_var);
  * @param default_value The default value to return if not defined.
  * @return The environment variable's value.
  */
-std::string get(env_var_key env_var, const std::string& default_value = "");
+std::string get(env_var_key env_var, std::string_view default_value = "");
 
 /**
  * @brief Gets the value of an environment variable as a number.

--- a/src/unrealsdk/game/bl2/bl2.h
+++ b/src/unrealsdk/game/bl2/bl2.h
@@ -109,7 +109,7 @@ template <>
 struct GameTraits<BL2Hook> {
     static constexpr auto NAME = "Borderlands 2";
 
-    static bool matches_executable(const std::string& executable) {
+    static bool matches_executable(std::string_view executable) {
         return executable == "Borderlands2.exe" || executable == "TinyTina.exe";
     }
 };

--- a/src/unrealsdk/game/bl3/bl3.h
+++ b/src/unrealsdk/game/bl3/bl3.h
@@ -104,7 +104,7 @@ template <>
 struct GameTraits<BL3Hook> {
     static constexpr auto NAME = "Borderlands 3";
 
-    static bool matches_executable(const std::string& executable) {
+    static bool matches_executable(std::string_view executable) {
         return executable == "Borderlands3.exe" || executable == "Wonderlands.exe";
     }
 };

--- a/src/unrealsdk/game/bl3/console.cpp
+++ b/src/unrealsdk/game/bl3/console.cpp
@@ -166,7 +166,7 @@ bool inject_console_hook(hook_manager::Details& hook) {
             console_key = existing_console_key;
         } else {
             auto wanted_console_key = env::get(env::CONSOLE_KEY, env::defaults::CONSOLE_KEY);
-            console_key = {wanted_console_key};
+            console_key = FName{wanted_console_key};
 
             inner_obj->get<UStructProperty>(L"ConsoleKey"_fn)
                 .set<UNameProperty>(L"KeyName"_fn, console_key);

--- a/src/unrealsdk/game/selector.cpp
+++ b/src/unrealsdk/game/selector.cpp
@@ -5,6 +5,7 @@
 #include "unrealsdk/game/bl2/bl2.h"
 #include "unrealsdk/game/bl3/bl3.h"
 #include "unrealsdk/game/tps/tps.h"
+#include "unrealsdk/utils.h"
 
 #ifndef UNREALSDK_IMPORTING
 
@@ -53,16 +54,7 @@ std::unique_ptr<AbstractHook> find_correct_hook(const std::string& executable) {
 }  // namespace
 
 std::unique_ptr<AbstractHook> select_based_on_executable(void) {
-    std::filesystem::path exe_path{};
-
-    std::array<char, FILENAME_MAX> buf{};
-    if (GetModuleFileNameA(nullptr, buf.data(), (DWORD)buf.size()) > 0) {
-        exe_path = std::filesystem::path(buf.data());
-    } else {
-        LOG(ERROR, "Failed to get main executable's path!");
-    }
-
-    auto executable = env::get(env::GAME_OVERRIDE, exe_path.filename().string());
+    auto executable = env::get(env::GAME_OVERRIDE, utils::get_executable().filename().string());
     return find_correct_hook(executable);
 }
 

--- a/src/unrealsdk/game/selector.cpp
+++ b/src/unrealsdk/game/selector.cpp
@@ -38,7 +38,7 @@ using all_known_games = std::tuple<BL2Hook, TPSHook>;
  * @param executable The executable name to match against.
  */
 template <int i = 0>
-std::unique_ptr<AbstractHook> find_correct_hook(const std::string& executable) {
+std::unique_ptr<AbstractHook> find_correct_hook(std::string_view executable) {
     if constexpr (i >= std::tuple_size_v<all_known_games>) {
         throw std::runtime_error("Failed to find compatible game hook!");
     } else {

--- a/src/unrealsdk/game/selector.h
+++ b/src/unrealsdk/game/selector.h
@@ -31,7 +31,7 @@ struct GameTraits {
      * @param executable The executable name to match.
      * @return True if the hook matches it.
      */
-    static bool matches_executable(const std::string& executable);
+    static bool matches_executable(std::string_view executable);
 };
 
 }  // namespace unrealsdk::game

--- a/src/unrealsdk/game/tps/tps.h
+++ b/src/unrealsdk/game/tps/tps.h
@@ -22,7 +22,7 @@ template <>
 struct GameTraits<TPSHook> {
     static constexpr auto NAME = "TPS";
 
-    static bool matches_executable(const std::string& executable) {
+    static bool matches_executable(std::string_view executable) {
         return executable == "BorderlandsPreSequel.exe";
     }
 };

--- a/src/unrealsdk/hook_manager.h
+++ b/src/unrealsdk/hook_manager.h
@@ -80,9 +80,9 @@ void inject_next_call(void);
  * @param callback The callback to run when the hooked function is called.
  * @return True if successfully added, false if an identical hook already existed.
  */
-bool add_hook(const std::wstring& func,
+bool add_hook(std::wstring_view func,
               Type type,
-              const std::wstring& identifier,
+              std::wstring_view identifier,
               const Callback& callback);
 
 /**
@@ -93,7 +93,7 @@ bool add_hook(const std::wstring& func,
  * @param identifier The hook identifier.
  * @return True if a hook with the given details exists.
  */
-bool has_hook(const std::wstring& func, Type type, const std::wstring& identifier);
+bool has_hook(std::wstring_view func, Type type, std::wstring_view identifier);
 
 /**
  * @brief Removes a hook.
@@ -103,7 +103,7 @@ bool has_hook(const std::wstring& func, Type type, const std::wstring& identifie
  * @param identifier The hook identifier.
  * @return True if successfully removed, false if no hook with the given details exists.
  */
-bool remove_hook(const std::wstring& func, Type type, const std::wstring& identifier);
+bool remove_hook(std::wstring_view func, Type type, std::wstring_view identifier);
 
 namespace impl {  // These functions are only relevant when implementing a game hook
 
@@ -140,7 +140,7 @@ to work out if to early exit again. If it does, it can spend a bit longer extrac
  * @param obj The object which called the function.
  * @return A pointer to the relevant hook list, or nullptr if no hooks match.
  */
-const List* preprocess_hook(const std::string& source,
+const List* preprocess_hook(std::string_view source,
                             const unreal::UFunction* func,
                             const unreal::UObject* obj);
 

--- a/src/unrealsdk/logging.cpp
+++ b/src/unrealsdk/logging.cpp
@@ -64,7 +64,7 @@ const std::string TRUNCATION_PREFIX = "~ ";
  * @return The truncated string.
  */
 std::string truncate_leading_chunks(const std::string&& str,
-                                    const std::string& separators,
+                                    std::string_view separators,
                                     size_t max_width) {
     auto width = str.size();
     size_t start_pos = 0;
@@ -156,7 +156,7 @@ std::string get_header(void) {
  * @param str The string.
  * @return The parsed log level, or `Level::INVALID`.
  */
-Level get_level_from_string(const std::string& str) {
+Level get_level_from_string(std::string_view str) {
     if (str.empty()) {
         return Level::INVALID;
     }
@@ -179,7 +179,7 @@ Level get_level_from_string(const std::string& str) {
 
     // Otherwise try parse as an int
     uint32_t int_level = 0;
-    auto res = std::from_chars(str.c_str(), str.c_str() + str.size(), int_level);
+    auto res = std::from_chars(str.data(), str.data() + str.size(), int_level);
     if (res.ec == std::errc()) {
         return Level::INVALID;
     }
@@ -274,14 +274,14 @@ UNREALSDK_CAPI(void, log_msg_internal, const LogMessage* msg) {
 
 }  // namespace
 
-void log(Level level, const std::string& msg, const char* location, int line) {
-    const LogMessage log_msg{unix_ms_now(), level, msg.c_str(), msg.size(), location, line};
+void log(Level level, std::string_view msg, const char* location, int line) {
+    const LogMessage log_msg{unix_ms_now(), level, msg.data(), msg.size(), location, line};
     UNREALSDK_MANGLE(log_msg_internal)(&log_msg);
 }
 
-void log(Level level, const std::wstring& msg, const char* location, int line) {
+void log(Level level, std::wstring_view msg, const char* location, int line) {
     auto narrow = utils::narrow(msg);
-    const LogMessage log_msg{unix_ms_now(), level, narrow.c_str(), narrow.size(), location, line};
+    const LogMessage log_msg{unix_ms_now(), level, narrow.data(), narrow.size(), location, line};
     UNREALSDK_MANGLE(log_msg_internal)(&log_msg);
 }
 

--- a/src/unrealsdk/logging.h
+++ b/src/unrealsdk/logging.h
@@ -61,8 +61,8 @@ void init(const std::filesystem::path& file, bool callbacks_only = false);
  *                 colon-namespaced function name.
  * @param line The line number the message was logged from.
  */
-void log(Level level, const std::string& msg, const char* location, int line);
-void log(Level level, const std::wstring& msg, const char* location, int line);
+void log(Level level, std::string_view msg, const char* location, int line);
+void log(Level level, std::wstring_view msg, const char* location, int line);
 
 /**
  * @brief Sets the log level of the unreal console.

--- a/src/unrealsdk/memory.cpp
+++ b/src/unrealsdk/memory.cpp
@@ -79,11 +79,11 @@ UNREALSDK_CAPI(bool,
                size_t name_size);
 #endif
 #ifdef UNREALSDK_IMPORTING
-bool detour(uintptr_t addr, void* detour_func, void** original_func, const std::string& name) {
-    return UNREALSDK_MANGLE(detour)(addr, detour_func, original_func, name.c_str(), name.size());
+bool detour(uintptr_t addr, void* detour_func, void** original_func, std::string_view name) {
+    return UNREALSDK_MANGLE(detour)(addr, detour_func, original_func, name.data(), name.size());
 }
 #else
-bool detour(uintptr_t addr, void* detour_func, void** original_func, const std::string& name) {
+bool detour(uintptr_t addr, void* detour_func, void** original_func, std::string_view name) {
     MH_STATUS status = MH_OK;
 
     status = MH_CreateHook(reinterpret_cast<LPVOID>(addr), detour_func, original_func);

--- a/src/unrealsdk/memory.h
+++ b/src/unrealsdk/memory.h
@@ -45,9 +45,9 @@ T sigscan(const uint8_t* bytes,
  * @param name Name of the detour, to be used in log messages on error.
  * @return True if the detour was successfully created.
  */
-bool detour(uintptr_t addr, void* detour_func, void** original_func, const std::string& name);
+bool detour(uintptr_t addr, void* detour_func, void** original_func, std::string_view name);
 template <typename T>
-bool detour(uintptr_t addr, T detour_func, T* original_func, const std::string& name) {
+bool detour(uintptr_t addr, T detour_func, T* original_func, std::string_view name) {
     return detour(addr, reinterpret_cast<void*>(detour_func),
                   reinterpret_cast<void**>(original_func), name);
 }

--- a/src/unrealsdk/pch.h
+++ b/src/unrealsdk/pch.h
@@ -38,6 +38,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>

--- a/src/unrealsdk/unreal/find_class.cpp
+++ b/src/unrealsdk/unreal/find_class.cpp
@@ -45,17 +45,17 @@ UNREALSDK_CAPI([[nodiscard]] UClass*, find_class_fname, const FName* name) {
 UNREALSDK_CAPI([[nodiscard]] UClass*, find_class_cstr, const wchar_t* name, size_t name_size);
 #endif
 #ifdef UNREALSDK_IMPORTING
-UClass* find_class(const std::wstring& name) {
-    return UNREALSDK_MANGLE(find_class_cstr)(name.c_str(), name.size());
+UClass* find_class(std::wstring_view name) {
+    return UNREALSDK_MANGLE(find_class_cstr)(name.data(), name.size());
 }
 #else
-UClass* find_class(const std::wstring& name) {
+UClass* find_class(std::wstring_view name) {
     return cache.find(name);
 }
 #endif
 #ifdef UNREALSDK_EXPORTING
 UNREALSDK_CAPI([[nodiscard]] UClass*, find_class_cstr, const wchar_t* name, size_t name_size) {
-    return find_class(std::wstring{name, name_size});
+    return find_class(std::wstring_view{name, name_size});
 }
 #endif
 

--- a/src/unrealsdk/unreal/find_class.h
+++ b/src/unrealsdk/unreal/find_class.h
@@ -24,7 +24,7 @@ template <typename T>
     return find_class(cls_fname<T>());
 }
 [[nodiscard]] UClass* find_class(const FName& name);
-[[nodiscard]] UClass* find_class(const std::wstring& name);
+[[nodiscard]] UClass* find_class(std::wstring_view name);
 
 }  // namespace unrealsdk::unreal
 

--- a/src/unrealsdk/unreal/namedobjectcache.h
+++ b/src/unrealsdk/unreal/namedobjectcache.h
@@ -93,7 +93,7 @@ class NamedObjectCache {
 
         return this->cache[name];
     }
-    [[nodiscard]] CacheType find(const std::wstring& name) {
+    [[nodiscard]] CacheType find(std::wstring_view name) {
         this->ensure_initialized();
 
         auto obj = validate_type<ObjectType>(unrealsdk::find_object(this->uclass, name));

--- a/src/unrealsdk/unreal/structs/fname.cpp
+++ b/src/unrealsdk/unreal/structs/fname.cpp
@@ -9,8 +9,8 @@ namespace unrealsdk::unreal {
 
 FName::FName(int32_t index, int32_t number) : index(index), number(number) {}
 
-FName::FName(const std::string& name, int32_t number) : FName(utils::widen(name), number){};
-FName::FName(const std::wstring& name, int32_t number) {
+FName::FName(std::string_view name, int32_t number) : FName(utils::widen(name), number){};
+FName::FName(std::wstring_view name, int32_t number) {
     unrealsdk::fname_init(this, name, number);
 }
 

--- a/src/unrealsdk/unreal/structs/fname.h
+++ b/src/unrealsdk/unreal/structs/fname.h
@@ -25,8 +25,8 @@ struct FName {
      */
     FName(void) = default;
     FName(int32_t index, int32_t number);
-    FName(const std::string& name, int32_t number = 0);
-    FName(const std::wstring& name, int32_t number = 0);
+    FName(std::string_view name, int32_t number = 0);
+    FName(std::wstring_view name, int32_t number = 0);
 
     bool operator==(const FName& other) const;
     bool operator!=(const FName& other) const;
@@ -70,7 +70,7 @@ FName operator"" _fn(const wchar_t* str, size_t len);
 template <>
 struct unrealsdk::fmt::formatter<unrealsdk::unreal::FName>
     : unrealsdk::fmt::formatter<std::string> {
-    auto format(unrealsdk::unreal::FName name, unrealsdk::fmt::format_context& ctx) {
+    auto format(unrealsdk::unreal::FName name, unrealsdk::fmt::format_context& ctx) const {
         return formatter<std::string>::format((std::string)name, ctx);
     }
 };

--- a/src/unrealsdk/unreal/structs/fstring.h
+++ b/src/unrealsdk/unreal/structs/fstring.h
@@ -30,7 +30,7 @@ struct TemporaryFString : public TArray<const wchar_t> {
      *
      * @param str The string this FString should contain.
      */
-    TemporaryFString(const std::wstring& str);
+    TemporaryFString(std::wstring_view str);
 
     /**
      * @brief Destroys the string.
@@ -58,8 +58,8 @@ struct UnmanagedFString : public TArray<wchar_t> {
     UnmanagedFString(decltype(data) data = nullptr,
                      decltype(count) count = 0,
                      decltype(max) max = 0);
-    UnmanagedFString(const std::string& str);
-    UnmanagedFString(const std::wstring& str);
+    UnmanagedFString(std::string_view str);
+    UnmanagedFString(std::wstring_view str);
     UnmanagedFString(UnmanagedFString&& other) noexcept;
 
     /**
@@ -75,8 +75,8 @@ struct UnmanagedFString : public TArray<wchar_t> {
      * @param other The other FString to assign this one from.
      * @return A reference to this FString.
      */
-    UnmanagedFString& operator=(const std::string& str);
-    UnmanagedFString& operator=(const std::wstring& str);
+    UnmanagedFString& operator=(std::string_view str);
+    UnmanagedFString& operator=(std::wstring_view str);
     UnmanagedFString& operator=(UnmanagedFString&& other) noexcept;
 
     /**
@@ -87,6 +87,7 @@ struct UnmanagedFString : public TArray<wchar_t> {
      */
     operator std::string() const;
     operator std::wstring() const;
+    operator std::wstring_view() const;
 
     // Delete copy construction/assignment since it's easy to leak memory with them.
     UnmanagedFString(const UnmanagedFString& other) = delete;

--- a/src/unrealsdk/unreal/structs/ftext.cpp
+++ b/src/unrealsdk/unreal/structs/ftext.cpp
@@ -11,15 +11,15 @@ namespace unrealsdk::unreal {
 
 #ifdef UE4
 
-FText::FText(const std::string& str) : FText(utils::widen(str)) {}
-FText::FText(const std::wstring& str) : data(), flags() {
+FText::FText(std::string_view str) : FText(utils::widen(str)) {}
+FText::FText(std::wstring_view str) : data(), flags() {
     unrealsdk::ftext_as_culture_invariant(this, str);
 }
 
-FText& FText::operator=(const std::string& str) {
+FText& FText::operator=(std::string_view str) {
     return *this = utils::widen(str);
 }
-FText& FText::operator=(const std::wstring& str) {
+FText& FText::operator=(std::wstring_view str) {
     // Modifying in place is a pain, instead create a new FText and swap it in
     FText local_text{str};
     std::swap(this->data, local_text.data);
@@ -31,9 +31,12 @@ FText& FText::operator=(const std::wstring& str) {
 }
 
 FText::operator std::string() const {
-    return utils::narrow(this->operator std::wstring());
+    return utils::narrow(this->operator std::wstring_view());
 }
 FText::operator std::wstring() const {
+    return std::wstring{this->operator std::wstring_view()};
+}
+FText::operator std::wstring_view() const {
     static auto idx = env::get_numeric<size_t>(env::FTEXT_GET_DISPLAY_STRING_VF_INDEX,
                                                env::defaults::FTEXT_GET_DISPLAY_STRING_VF_INDEX);
 
@@ -53,22 +56,22 @@ FText::~FText() {
 
 #else
 
-FText::FText(const std::string& /* str */) : data(), flags() {
+FText::FText(std::string_view /* str */) : data(), flags() {
     (void)this;
     (void)this->data;
     (void)this->flags;
     throw_version_error("FTexts are not implemented in UE3");
 }
-FText::FText(const std::wstring& /* str */) : data(), flags() {
+FText::FText(std::wstring_view /* str */) : data(), flags() {
     (void)this;
     throw_version_error("FTexts are not implemented in UE3");
 }
-FText& FText::operator=(const std::string& /* str */) {
+FText& FText::operator=(std::string_view /* str */) {
     (void)this;
     throw_version_error("FTexts are not implemented in UE3");
     return *this;
 }
-FText& FText::operator=(const std::wstring& /* str */) {
+FText& FText::operator=(std::wstring_view /* str */) {
     (void)this;
     throw_version_error("FTexts are not implemented in UE3");
     return *this;
@@ -79,6 +82,11 @@ FText::operator std::string() const {
     return {};
 }
 FText::operator std::wstring() const {
+    (void)this;
+    throw_version_error("FTexts are not implemented in UE3");
+    return {};
+}
+FText::operator std::wstring_view() const {
     (void)this;
     throw_version_error("FTexts are not implemented in UE3");
     return {};

--- a/src/unrealsdk/unreal/structs/ftext.h
+++ b/src/unrealsdk/unreal/structs/ftext.h
@@ -31,8 +31,8 @@ struct FText {
      * @param str The string to set it to. Always uses invariant culture.
      */
     FText() = default;
-    FText(const std::string& str);
-    FText(const std::wstring& str);
+    FText(std::string_view str);
+    FText(std::wstring_view str);
 
     /**
      * @brief Assigns a new value to the FText.
@@ -41,8 +41,8 @@ struct FText {
      * @param str The string to assign.
      * @return A reference to this FText.
      */
-    FText& operator=(const std::string& str);
-    FText& operator=(const std::wstring& str);
+    FText& operator=(std::string_view str);
+    FText& operator=(std::wstring_view str);
 
     /**
      * @brief Convert the FText to it's string representation.
@@ -52,6 +52,7 @@ struct FText {
      */
     operator std::string() const;
     operator std::wstring() const;
+    operator std::wstring_view() const;
 
     /**
      * @brief Destroys the FText.
@@ -75,7 +76,7 @@ struct FText {
 template <>
 struct unrealsdk::fmt::formatter<unrealsdk::unreal::FText>
     : unrealsdk::fmt::formatter<std::string> {
-    auto format(unrealsdk::unreal::FText text, unrealsdk::fmt::format_context& ctx) {
+    auto format(unrealsdk::unreal::FText text, unrealsdk::fmt::format_context& ctx) const {
         return formatter<std::string>::format((std::string)text, ctx);
     }
 };

--- a/src/unrealsdk/unrealsdk.h
+++ b/src/unrealsdk/unrealsdk.h
@@ -27,13 +27,16 @@ struct TemporaryFString;
 namespace unrealsdk {
 
 #ifndef UNREALSDK_IMPORTING
+
 /**
  * @brief Initializes the sdk.
+ * @note Logging is initialized before calling the getter, it is safe to log within it.
  *
- * @param game An instance of the hook type to use to hook the current game.
+ * @param game_getter A function which gets an instance of the hook type to use on the current game.
  * @return True if the sdk was initialized with the given game, false if it was already initialized.
  */
-bool init(std::unique_ptr<game::AbstractHook>&& game);
+bool init(const std::function<std::unique_ptr<game::AbstractHook>(void)>& game_getter);
+
 #endif
 
 /**

--- a/src/unrealsdk/unrealsdk.h
+++ b/src/unrealsdk/unrealsdk.h
@@ -77,7 +77,7 @@ bool init(std::unique_ptr<game::AbstractHook>&& game);
  * @param number The number to initialize the name to.
  */
 void fname_init(unreal::FName* name, const wchar_t* str, int32_t number);
-void fname_init(unreal::FName* name, const std::wstring& str, int32_t number);
+void fname_init(unreal::FName* name, std::wstring_view str, int32_t number);
 
 /**
  * @brief Calls FFrame::Step.

--- a/src/unrealsdk/unrealsdk.h
+++ b/src/unrealsdk/unrealsdk.h
@@ -153,7 +153,7 @@ void process_event(unreal::UObject* object, unreal::UFunction* func, void* param
  *
  * @param str The string to write.
  */
-void uconsole_output_text(const std::wstring& str);
+void uconsole_output_text(std::wstring_view str);
 
 /**
  * @brief Calls `UObject::PathName` on the given object.
@@ -170,9 +170,9 @@ void uconsole_output_text(const std::wstring& str);
  * @param name The object's full path name.
  * @return The object, or nullptr if unable to find.
  */
-[[nodiscard]] unreal::UObject* find_object(unreal::UClass* cls, const std::wstring& name);
-[[nodiscard]] unreal::UObject* find_object(const unreal::FName& cls, const std::wstring& name);
-[[nodiscard]] unreal::UObject* find_object(const std::wstring& cls, const std::wstring& name);
+[[nodiscard]] unreal::UObject* find_object(unreal::UClass* cls, std::wstring_view name);
+[[nodiscard]] unreal::UObject* find_object(const unreal::FName& cls, std::wstring_view name);
+[[nodiscard]] unreal::UObject* find_object(std::wstring_view cls, std::wstring_view name);
 
 #ifdef UE4
 

--- a/src/unrealsdk/unrealsdk_main.cpp
+++ b/src/unrealsdk/unrealsdk_main.cpp
@@ -52,7 +52,8 @@ bool init(std::unique_ptr<game::AbstractHook>&& game) {
     }
 
     env::load_file();
-    logging::init(utils::get_this_dll_dir() / env::get(env::LOG_FILE, env::defaults::LOG_FILE));
+    logging::init(utils::get_this_dll().parent_path()
+                  / env::get(env::LOG_FILE, env::defaults::LOG_FILE));
 
     auto version = unrealsdk::get_version_string();
     LOG(INFO, "{}", version);

--- a/src/unrealsdk/unrealsdk_main.cpp
+++ b/src/unrealsdk/unrealsdk_main.cpp
@@ -44,7 +44,7 @@ std::unique_ptr<game::AbstractHook> hook_instance;
 std::unordered_set<void*> unreal_allocations{};
 #endif
 
-bool init(std::unique_ptr<game::AbstractHook>&& game) {
+bool init(const std::function<std::unique_ptr<game::AbstractHook>(void)>& game_getter) {
     const std::lock_guard<std::mutex> lock(init_mutex);
 
     if (hook_instance != nullptr) {
@@ -63,9 +63,10 @@ bool init(std::unique_ptr<game::AbstractHook>&& game) {
         throw std::runtime_error("Minhook initialization failed!");
     }
 
+    auto game = game_getter();
+
     // Initialize the hook before moving it, to weed out any order of initialization problems.
     game->hook();
-
     hook_instance = std::move(game);
     return true;
 }

--- a/src/unrealsdk/unrealsdk_wrappers.cpp
+++ b/src/unrealsdk/unrealsdk_wrappers.cpp
@@ -33,8 +33,8 @@ const GNames& gnames(void) {
 void fname_init(FName* name, const wchar_t* str, int32_t number) {
     UNREALSDK_MANGLE(fname_init)(name, str, number);
 }
-void fname_init(FName* name, const std::wstring& str, int32_t number) {
-    UNREALSDK_MANGLE(fname_init)(name, str.c_str(), number);
+void fname_init(FName* name, std::wstring_view str, int32_t number) {
+    UNREALSDK_MANGLE(fname_init)(name, str.data(), number);
 }
 
 void fframe_step(FFrame* frame, UObject* obj, void* param) {

--- a/src/unrealsdk/unrealsdk_wrappers.cpp
+++ b/src/unrealsdk/unrealsdk_wrappers.cpp
@@ -63,8 +63,8 @@ UObject* construct_object(UClass* cls,
     return UNREALSDK_MANGLE(construct_object)(cls, outer, &name, flags, template_obj);
 }
 
-void uconsole_output_text(const std::wstring& str) {
-    UNREALSDK_MANGLE(uconsole_output_text)(str.c_str(), str.size());
+void uconsole_output_text(std::wstring_view str) {
+    UNREALSDK_MANGLE(uconsole_output_text)(str.data(), str.size());
 }
 
 std::wstring uobject_path_name(const UObject* obj) {
@@ -76,14 +76,14 @@ std::wstring uobject_path_name(const UObject* obj) {
     return str;
 }
 
-UObject* find_object(UClass* cls, const std::wstring& name) {
-    return UNREALSDK_MANGLE(find_object)(cls, name.c_str(), name.size());
+UObject* find_object(UClass* cls, std::wstring_view name) {
+    return UNREALSDK_MANGLE(find_object)(cls, name.data(), name.size());
 }
-UObject* find_object(const FName& cls, const std::wstring& name) {
-    return UNREALSDK_MANGLE(find_object)(find_class(cls), name.c_str(), name.size());
+UObject* find_object(const FName& cls, std::wstring_view name) {
+    return UNREALSDK_MANGLE(find_object)(find_class(cls), name.data(), name.size());
 }
-UObject* find_object(const std::wstring& cls, const std::wstring& name) {
-    return UNREALSDK_MANGLE(find_object)(find_class(cls), name.c_str(), name.size());
+UObject* find_object(std::wstring_view cls, std::wstring_view name) {
+    return UNREALSDK_MANGLE(find_object)(find_class(cls), name.data(), name.size());
 }
 
 #ifdef UE4

--- a/src/unrealsdk/utils.cpp
+++ b/src/unrealsdk/utils.cpp
@@ -4,8 +4,6 @@
 
 namespace unrealsdk::utils {
 
-// NOLINTBEGIN(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory)
-
 static_assert(sizeof(wchar_t) == sizeof(char16_t), "wchar_t is different size to char16_t");
 
 std::string narrow(std::wstring_view wstr) {
@@ -43,26 +41,53 @@ std::wstring widen(std::string_view str) {
     return ret;
 }
 
-std::filesystem::path get_this_dll_dir(void) {
+namespace {
+
+/**
+ * @brief Gets the path of a module.
+ *
+ * @param module The module to get the path of.
+ * @return The module's path.
+ */
+std::filesystem::path get_module_path(HMODULE module) {
+    // Use wchars here since it's the native path type on Windows, so won't need a conversion
+    wchar_t buf[MAX_PATH];
+    auto num_chars = GetModuleFileNameW(module, &buf[0], ARRAYSIZE(buf));
+    if (num_chars == 0) {
+        throw std::runtime_error("Failed to get get module filename!");
+    }
+
+    auto begin = &buf[0];
+    return {begin, begin + num_chars};
+}
+
+/**
+ * @brief Get a handle to the module this function is compiled into.
+ * @note Does not increase the refcount.
+ *
+ * @return A handle to this module
+ */
+HMODULE get_this_module(void) {
     HMODULE this_module = nullptr;
     if (GetModuleHandleExA(
             GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-            reinterpret_cast<LPCSTR>(&get_this_dll_dir), &this_module)
+            reinterpret_cast<LPCSTR>(&get_this_module), &this_module)
         == 0) {
-        // On error, better to return an empty path, i.e. the cwd
-        // This is called to get the path of the log file, so if we threw we wouldn't have anything
-        // to log the error to
-        return {};
+        throw std::runtime_error("Failed to get this module's handle!");
     }
-
-    char buf[MAX_PATH];
-    if (GetModuleFileNameA(this_module, &buf[0], sizeof(buf)) == 0) {
-        return {};
-    }
-
-    return std::filesystem::path{buf}.parent_path();
+    return this_module;
 }
 
-// NOLINTEND(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory)
+}  // namespace
+
+std::filesystem::path get_this_dll(void) {
+    static const std::filesystem::path path = get_module_path(get_this_module());
+    return path;
+}
+
+std::filesystem::path get_executable(void) {
+    static const std::filesystem::path path = get_module_path(nullptr);
+    return path;
+}
 
 }  // namespace unrealsdk::utils

--- a/src/unrealsdk/utils.h
+++ b/src/unrealsdk/utils.h
@@ -23,12 +23,19 @@ namespace unrealsdk::utils {
 
 /**
  * @brief Get the directory this dll is in.
- * @note Since this is not exported, calls from dlls linking against the shared library return their
- *       own dir, since this function will be linked statically.
+ * @note This function is linked statically, calls from dlls linking against the shared library will
+ *       return their own path.
  *
  * @return The path of the dll this function is compiled into.
  */
-[[nodiscard]] std::filesystem::path get_this_dll_dir(void);
+[[nodiscard]] std::filesystem::path get_this_dll(void);
+
+/**
+ * @brief Get the main executable we're running within.
+ *
+ * @return The path of the main executable.
+ */
+[[nodiscard]] std::filesystem::path get_executable(void);
 
 /**
  * @brief Proxy class for an iterator, used to allow multiple range iterators on the same class.

--- a/src/unrealsdk/utils.h
+++ b/src/unrealsdk/utils.h
@@ -136,7 +136,7 @@ struct DLLSafeCallback {
 // Custom wstring formatter, which calls narrow
 template <>
 struct unrealsdk::fmt::formatter<std::wstring> : unrealsdk::fmt::formatter<std::string> {
-    auto format(const std::wstring& str, unrealsdk::fmt::format_context& ctx) {
+    auto format(const std::wstring& str, unrealsdk::fmt::format_context& ctx) const {
         return formatter<std::string>::format(unrealsdk::utils::narrow(str), ctx);
     }
 };

--- a/src/unrealsdk/utils.h
+++ b/src/unrealsdk/utils.h
@@ -131,6 +131,31 @@ struct DLLSafeCallback {
     R operator()(As... args) { return this->vftable->call(this, args...); }
 };
 
+namespace {
+
+template <typename T>
+struct StringViewHash {
+    using is_transparent = void;
+
+    [[nodiscard]] size_t operator()(const T& str) const { return std::hash<T>{}(str); }
+    [[nodiscard]] size_t operator()(
+        std::basic_string_view<typename T::value_type, typename T::traits_type> str) const {
+        return std::hash<std::basic_string_view<typename T::value_type, typename T::traits_type>>{}(
+            str);
+    }
+};
+
+}  // namespace
+
+/**
+ * @brief A map where the key is a string, which may also be compared using a string view.
+ *
+ * @tparam Key The key string type to use.
+ * @tparam T The value type.
+ */
+template <typename Key, typename T, typename Allocator = std::allocator<std::pair<const Key, T>>>
+using StringViewMap = std::unordered_map<Key, T, StringViewHash<Key>, std::equal_to<>, Allocator>;
+
 }  // namespace unrealsdk::utils
 
 // Custom wstring formatter, which calls narrow

--- a/src/unrealsdk/utils.h
+++ b/src/unrealsdk/utils.h
@@ -11,7 +11,7 @@ namespace unrealsdk::utils {
  * @param str The input wstring.
  * @return The output string.
  */
-[[nodiscard]] std::string narrow(const std::wstring& wstr);
+[[nodiscard]] std::string narrow(std::wstring_view wstr);
 
 /**
  * @brief Widens a utf-8 string to a utf-16 wstring.
@@ -19,7 +19,7 @@ namespace unrealsdk::utils {
  * @param str The input string.
  * @return The output wstring.
  */
-[[nodiscard]] std::wstring widen(const std::string& str);
+[[nodiscard]] std::wstring widen(std::string_view str);
 
 /**
  * @brief Get the directory this dll is in.


### PR DESCRIPTION
also includes:
- removing a few extra allocations in some of the string manip functions
- initialize logging *before* selecting the game, so that errors will be visible