### PR TITLE
rename arg to avoid shadowing member

### DIFF
--- a/src/unrealsdk/unreal/structs/fscriptdelegate.cpp
+++ b/src/unrealsdk/unreal/structs/fscriptdelegate.cpp
@@ -15,8 +15,8 @@ UObject* FScriptDelegate::get_object(void) const {
     return this->object;
 }
 
-void FScriptDelegate::set_object(UObject* object) {
-    this->object = object;
+void FScriptDelegate::set_object(UObject* obj) {
+    this->object = obj;
 }
 
 #else

--- a/src/unrealsdk/unreal/structs/fscriptdelegate.h
+++ b/src/unrealsdk/unreal/structs/fscriptdelegate.h
@@ -38,7 +38,7 @@ struct FScriptDelegate {
      *
      * @param object The object.
      */
-    void set_object(UObject* object);
+    void set_object(UObject* obj);
 
     /**
      * @brief Tries to convert this delegate to a bound function.


### PR DESCRIPTION
this triggered C4458 in the pyunrealsdk build
not sure why it didn't break our build